### PR TITLE
Add onCameraMove parameter

### DIFF
--- a/lib/interactive_maps_marker.dart
+++ b/lib/interactive_maps_marker.dart
@@ -27,7 +27,7 @@ class InteractiveMapsMarker extends StatefulWidget {
   final double zoomFocus;
   final bool zoomKeepOnTap;
   void Function(CameraPosition)? onCameraMove;
-  void Function? onCameraIdle;
+  void Function()? onCameraIdle;
   @required
   List<MarkerItem> items;
   @required

--- a/lib/interactive_maps_marker.dart
+++ b/lib/interactive_maps_marker.dart
@@ -80,6 +80,8 @@ class InteractiveMapsMarker extends StatefulWidget {
     }
     return state;
   }
+
+  void Function(CameraPosition)? get onCameraMove => onCameraMove;
 }
 
 class InteractiveMapsMarkerState extends State<InteractiveMapsMarker> {
@@ -90,7 +92,6 @@ class InteractiveMapsMarkerState extends State<InteractiveMapsMarker> {
   Set<Marker> markers = {};
   int currentIndex = 0;
   ValueNotifier selectedMarker = ValueNotifier<int?>(0);
-
   @override
   void initState() {
     rebuildMarkers(currentIndex);
@@ -151,7 +152,7 @@ class InteractiveMapsMarkerState extends State<InteractiveMapsMarker> {
             myLocationEnabled: true,
             myLocationButtonEnabled: false,
             onMapCreated: _onMapCreated,
-            onCameraMove: _onCameraMove,
+            onCameraMove: onCameraMove,
             initialCameraPosition: CameraPosition(
               target: widget.center,
               zoom: widget.zoom,

--- a/lib/interactive_maps_marker.dart
+++ b/lib/interactive_maps_marker.dart
@@ -16,11 +16,8 @@ class MarkerItem {
   double latitude;
   double longitude;
 
-  MarkerItem({
-    required this.id,
-    required this.latitude,
-    required this.longitude,
-  });
+  MarkerItem(
+      {required this.id, required this.latitude, required this.longitude});
 }
 
 class InteractiveMapsMarker extends StatefulWidget {
@@ -83,8 +80,6 @@ class InteractiveMapsMarker extends StatefulWidget {
     }
     return state;
   }
-
-  void Function(CameraPosition)? get onCameraMove => onCameraMove;
 }
 
 class InteractiveMapsMarkerState extends State<InteractiveMapsMarker> {
@@ -95,7 +90,6 @@ class InteractiveMapsMarkerState extends State<InteractiveMapsMarker> {
   Set<Marker> markers = {};
   int currentIndex = 0;
   ValueNotifier selectedMarker = ValueNotifier<int?>(0);
-
   @override
   void initState() {
     rebuildMarkers(currentIndex);
@@ -156,7 +150,7 @@ class InteractiveMapsMarkerState extends State<InteractiveMapsMarker> {
             myLocationEnabled: true,
             myLocationButtonEnabled: false,
             onMapCreated: _onMapCreated,
-            onCameraMove: onCameraMove,
+            onCameraMove: widget.onCameraMove,
             initialCameraPosition: CameraPosition(
               target: widget.center,
               zoom: widget.zoom,

--- a/lib/interactive_maps_marker.dart
+++ b/lib/interactive_maps_marker.dart
@@ -27,6 +27,7 @@ class InteractiveMapsMarker extends StatefulWidget {
   final double zoomFocus;
   final bool zoomKeepOnTap;
   void Function(CameraPosition)? onCameraMove;
+  void Function? onCameraIdle;
   @required
   List<MarkerItem> items;
   @required
@@ -53,6 +54,7 @@ class InteractiveMapsMarker extends StatefulWidget {
     this.controller,
     this.onLastItem,
     this.onCameraMove,
+    this.onCameraIdle,
   }) {
     if (itemBuilder == null && itemContent == null) {
       throw Exception('itemBuilder or itemContent must be provided');
@@ -151,6 +153,7 @@ class InteractiveMapsMarkerState extends State<InteractiveMapsMarker> {
             myLocationButtonEnabled: false,
             onMapCreated: _onMapCreated,
             onCameraMove: widget.onCameraMove,
+            onCameraIdle: widget.onCameraIdle,
             initialCameraPosition: CameraPosition(
               target: widget.center,
               zoom: widget.zoom,

--- a/lib/interactive_maps_marker.dart
+++ b/lib/interactive_maps_marker.dart
@@ -12,7 +12,7 @@ export 'package:interactive_maps_marker/interactive_maps_controller.dart';
 import './utils.dart';
 
 class MarkerItem {
-  int id;
+  String id;
   double latitude;
   double longitude;
 

--- a/lib/interactive_maps_marker.dart
+++ b/lib/interactive_maps_marker.dart
@@ -16,8 +16,11 @@ class MarkerItem {
   double latitude;
   double longitude;
 
-  MarkerItem(
-      {required this.id, required this.latitude, required this.longitude});
+  MarkerItem({
+    required this.id,
+    required this.latitude,
+    required this.longitude,
+  });
 }
 
 class InteractiveMapsMarker extends StatefulWidget {
@@ -80,6 +83,8 @@ class InteractiveMapsMarker extends StatefulWidget {
     }
     return state;
   }
+
+  void Function(CameraPosition)? get onCameraMove => onCameraMove;
 }
 
 class InteractiveMapsMarkerState extends State<InteractiveMapsMarker> {
@@ -90,6 +95,7 @@ class InteractiveMapsMarkerState extends State<InteractiveMapsMarker> {
   Set<Marker> markers = {};
   int currentIndex = 0;
   ValueNotifier selectedMarker = ValueNotifier<int?>(0);
+
   @override
   void initState() {
     rebuildMarkers(currentIndex);
@@ -150,7 +156,7 @@ class InteractiveMapsMarkerState extends State<InteractiveMapsMarker> {
             myLocationEnabled: true,
             myLocationButtonEnabled: false,
             onMapCreated: _onMapCreated,
-            onCameraMove: widget.onCameraMove,
+            onCameraMove: onCameraMove,
             initialCameraPosition: CameraPosition(
               target: widget.center,
               zoom: widget.zoom,

--- a/lib/interactive_maps_marker.dart
+++ b/lib/interactive_maps_marker.dart
@@ -12,11 +12,12 @@ export 'package:interactive_maps_marker/interactive_maps_controller.dart';
 import './utils.dart';
 
 class MarkerItem {
-  String id;
+  int id;
   double latitude;
   double longitude;
 
-  MarkerItem({required this.id, required this.latitude, required this.longitude});
+  MarkerItem(
+      {required this.id, required this.latitude, required this.longitude});
 }
 
 class InteractiveMapsMarker extends StatefulWidget {
@@ -25,6 +26,7 @@ class InteractiveMapsMarker extends StatefulWidget {
   final double zoom;
   final double zoomFocus;
   final bool zoomKeepOnTap;
+  void Function(CameraPosition)? onCameraMove;
   @required
   List<MarkerItem> items;
   @required
@@ -50,16 +52,21 @@ class InteractiveMapsMarker extends StatefulWidget {
     this.contentAlignment = Alignment.bottomCenter,
     this.controller,
     this.onLastItem,
-  }){
-    if(itemBuilder == null && itemContent == null){
+    this.onCameraMove,
+  }) {
+    if (itemBuilder == null && itemContent == null) {
       throw Exception('itemBuilder or itemContent must be provided');
     }
     readIcons();
   }
 
   void readIcons() async {
-    if (markerIcon == null) markerIcon = await getBytesFromAsset('packages/interactive_maps_marker/assets/marker.png', 100);
-    if (markerIconSelected == null) markerIconSelected = await getBytesFromAsset('packages/interactive_maps_marker/assets/marker_selected.png', 100);
+    if (markerIcon == null)
+      markerIcon = await getBytesFromAsset(
+          'packages/interactive_maps_marker/assets/marker.png', 100);
+    if (markerIconSelected == null)
+      markerIconSelected = await getBytesFromAsset(
+          'packages/interactive_maps_marker/assets/marker_selected.png', 100);
   }
 
   Uint8List? markerIcon;
@@ -68,7 +75,7 @@ class InteractiveMapsMarker extends StatefulWidget {
   @override
   InteractiveMapsMarkerState createState() {
     var state = InteractiveMapsMarkerState();
-    if(controller != null){
+    if (controller != null) {
       controller!.currentState(state);
     }
     return state;
@@ -119,7 +126,9 @@ class InteractiveMapsMarkerState extends State<InteractiveMapsMarker> {
                     itemCount: widget.items.length,
                     controller: pageController,
                     onPageChanged: _pageChanged,
-                    itemBuilder: widget.itemBuilder != null ? widget.itemBuilder! : _buildItem,
+                    itemBuilder: widget.itemBuilder != null
+                        ? widget.itemBuilder!
+                        : _buildItem,
                   ),
                 ),
               ),
@@ -142,6 +151,7 @@ class InteractiveMapsMarkerState extends State<InteractiveMapsMarker> {
             myLocationEnabled: true,
             myLocationButtonEnabled: false,
             onMapCreated: _onMapCreated,
+            onCameraMove: _onCameraMove,
             initialCameraPosition: CameraPosition(
               target: widget.center,
               zoom: widget.zoom,
@@ -178,7 +188,7 @@ class InteractiveMapsMarkerState extends State<InteractiveMapsMarker> {
   void _pageChanged(int index) {
     try {
       setState(() => currentIndex = index);
-      if(widget.onLastItem != null && index == widget.items.length - 1){
+      if (widget.onLastItem != null && index == widget.items.length - 1) {
         widget.onLastItem!();
       }
       rebuildMarkers(index);
@@ -203,7 +213,7 @@ class InteractiveMapsMarkerState extends State<InteractiveMapsMarker> {
   }
 
   Future<void> rebuildMarkers(int index) async {
-    if(widget.items.length == 0) return;
+    if (widget.items.length == 0) return;
     int current = widget.items[index].id;
 
     Set<Marker> _markers = Set<Marker>();
@@ -214,7 +224,8 @@ class InteractiveMapsMarkerState extends State<InteractiveMapsMarker> {
           markerId: MarkerId(item.id.toString()),
           position: LatLng(item.latitude, item.longitude),
           onTap: () {
-            int tappedIndex = widget.items.indexWhere((element) => element.id == item.id);
+            int tappedIndex =
+                widget.items.indexWhere((element) => element.id == item.id);
             pageController.animateToPage(
               tappedIndex,
               duration: Duration(milliseconds: 300),
@@ -222,7 +233,9 @@ class InteractiveMapsMarkerState extends State<InteractiveMapsMarker> {
             );
             _pageChanged(tappedIndex);
           },
-          icon:  BitmapDescriptor.defaultMarkerWithHue(item.id == current ? BitmapDescriptor.hueGreen : BitmapDescriptor.hueRed),
+          icon: BitmapDescriptor.defaultMarkerWithHue(item.id == current
+              ? BitmapDescriptor.hueGreen
+              : BitmapDescriptor.hueRed),
           // icon: item.id == current ? BitmapDescriptor.fromBytes(widget.markerIconSelected!) : BitmapDescriptor.fromBytes(widget.markerIcon!),
         ),
       );
@@ -236,7 +249,7 @@ class InteractiveMapsMarkerState extends State<InteractiveMapsMarker> {
     // selectedMarker.notifyListeners();
   }
 
-  void setIndex(int index){
+  void setIndex(int index) {
     pageController.animateToPage(
       index,
       duration: Duration(milliseconds: 300),

--- a/lib/interactive_maps_marker.dart
+++ b/lib/interactive_maps_marker.dart
@@ -80,8 +80,6 @@ class InteractiveMapsMarker extends StatefulWidget {
     }
     return state;
   }
-
-  void Function(CameraPosition)? get onCameraMove => onCameraMove;
 }
 
 class InteractiveMapsMarkerState extends State<InteractiveMapsMarker> {
@@ -152,7 +150,7 @@ class InteractiveMapsMarkerState extends State<InteractiveMapsMarker> {
             myLocationEnabled: true,
             myLocationButtonEnabled: false,
             onMapCreated: _onMapCreated,
-            onCameraMove: onCameraMove,
+            onCameraMove: widget.onCameraMove,
             initialCameraPosition: CameraPosition(
               target: widget.center,
               zoom: widget.zoom,


### PR DESCRIPTION
This pull request adds the `onCameraMove` parameter to the `GoogleMap` widget to listen camera position changes.

I add this parameter to update the items on map when the camera position changes.